### PR TITLE
#26441 update multilingual integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.4.0]
+### Fixed
+* when multilingual is adding new tranlsation, plugin will store whole translation field instead of just language #26441
+
+### Changed
+* plugin will listen to `flotiq-multilingual.translation::changed` event (in previous multilingual plugin version it was `flotiq-multilingual.translation::added`) #26441
+
 ## [0.3.0]
 ### Fixed
 * storing nested objects in yjs doc #26528

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -2,7 +2,7 @@
   "id": "flotiq.live-preview",
   "name": "Live Preview",
   "description": "The Live Preview Plugin is used for real-time transmission of data from content object forms, allowing the end application to display content changes live.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": "https://github.com/flotiq/flotiq-ui-plugin-live-preview",
   "url": "https://localhost:3053/index.js",
   "permissions": []

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -6,7 +6,7 @@ import { clearConnections } from "../common/websockets";
 import { handleManagePlugin } from "./manage-form";
 import { handlePanelPlugin } from "./sidebar-panel";
 import cssString from "inline:./styles/index.css";
-import { handleAddTranslation } from "./mulitlingual-translations";
+import { handleChangeTranslation } from "./mulitlingual-translations";
 
 const loadStyles = () => {
   if (!document.getElementById(`${pluginInfo.id}-styles`)) {
@@ -46,8 +46,8 @@ registerFn(
       }
     });
 
-    handler.on("flotiq-multilingual.translation::added", (data) => {
-      handleAddTranslation(data, getPluginSettings, getSpaceId, getApiUrl);
+    handler.on("flotiq-multilingual.translation::changed", (data) => {
+      handleChangeTranslation(data, getPluginSettings, getSpaceId, getApiUrl);
     });
   },
 );

--- a/plugins/mulitlingual-translations/index.js
+++ b/plugins/mulitlingual-translations/index.js
@@ -1,8 +1,8 @@
 import { getObjectWSConnection } from "../../common/websockets";
 import { updateObjectDoc } from "../../common/yjs";
 
-export const handleAddTranslation = (
-  { fieldName, language, initialData, contentType },
+export const handleChangeTranslation = (
+  { fieldName, initialData, contentType, newTranslation },
   getPluginSettings,
   getSpaceId,
   getApiUrl,
@@ -18,8 +18,8 @@ export const handleAddTranslation = (
   if (!wsConnection) return;
 
   updateObjectDoc(
-    `${fieldName}.__language`,
-    language,
+    fieldName,
+    newTranslation,
     contentType?.schemaDefinition?.allOf?.[1]?.properties,
     wsConnection.doc,
   );


### PR DESCRIPTION
This PR is updating integration with multilingual plugin. From newest version of multilingual plugin, the event for adding translation is named  "flotiq-multilingual.translation::changed" instead of "flotiq-multilingual.translation::added" (https://github.com/flotiq/flotiq-ui-plugin-multilingual/pull/9).

This PR also fix how data in websocket is stored on new translation added