### PR TITLE
Working implementation of plugin working with the new collab gateway.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,6 +4,9 @@ module.exports = {
     browser: true,
     es6: true,
   },
+  globals: {
+    process: "readonly",
+  },
   extends: ["eslint:recommended", "prettier"],
   parserOptions: {
     sourceType: "module",

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.env*.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.8.0]
+### Added
+* websocket debug panel for inspecting active rooms, Yjs documents and awareness state #27596
+* send refetch signal after successful form submit so live preview can reload saved content #27596
+
+### Changed
+* redesigned websocket integration to work with the new collaboration gateway #27596
+* generated live preview URLs now include `identifyingFields` resolved from the route template #27596
+
+### Fixed
+* array editing no longer removes objects from the Yjs document unexpectedly
+* colors assigned to editor no longer produce incorrect lightness value
+* changes made in list object will no longer remove the remaining list items
+* connection is now correctly closed only for the edited document
+* connection is now correctly reestablished when any network failures happen while working on the document
+
 ## [0.7.4]
 ### Fixed
 * updating relations #27291

--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,30 @@ Imagine you've already have draft for a blog post, but now you want to make some
 
 ![Live preview button](./.docs/live-preview-button.png)
 
+### Websocket debug panel
+
+When troubleshooting live preview synchronization, you can enable a debug panel that shows active websocket rooms and Yjs state details.
+
+1. Open Flotiq editor with this plugin loaded.
+2. Open the browser developer console.
+3. Run:
+   ```javascript
+   sessionStorage.setItem("flotiq-live-preview-debug", "1")
+   ```
+
+The panel appears in the bottom-right corner and displays:
+
+- total websocket connections,
+- room-level connection status,
+- Yjs document details (`guid`, `clientId`, shared collections),
+- awareness states for connected clients.
+
+To disable it, click the panel close button or run:
+
+```javascript
+sessionStorage.setItem("flotiq-live-preview-debug", "0")
+```
+
 ## Configuration
 
 ![Live Preview settings](./.docs/live-preview-settings.png)

--- a/common/settings-parser.js
+++ b/common/settings-parser.js
@@ -13,3 +13,12 @@ export const getCtdSettings = (pluginSettings, contentTypeName) => {
       api_key: parsedSettings.api_key,
     }));
 };
+
+export const getGlobalSettings = (pluginSettings) => {
+  const parsedSettings = JSON.parse(pluginSettings || "{}");
+  return {
+    editor_key: parsedSettings.editor_key,
+    base_url: parsedSettings.base_url,
+    api_key: parsedSettings.api_key,
+  };
+};

--- a/common/websockets.js
+++ b/common/websockets.js
@@ -17,7 +17,7 @@ function getWebSocketEndpoint(apiUrl) {
 
   return apiUrl !== "https://api.flotiq.com"
     ? "wss://flotiq-websockets-staging.dev.cdwv.pl"
-    : "wss://sockets.flotiq.com";
+    : "wss://collab-gateway.flotiq.com";
 }
 
 function disposeConnection(roomId) {

--- a/common/websockets.js
+++ b/common/websockets.js
@@ -1,47 +1,80 @@
 import { WebsocketProvider } from "y-websocket";
 import * as Y from "yjs";
 import { getUserColor } from "../plugins/field-config/user-colors";
-import { getCtdSettings } from "./settings-parser";
+import { getGlobalSettings } from "./settings-parser";
+import { renderDebugPanel } from "./ws-debug-panel";
 
 const connections = new Map();
+
+renderDebugPanel(connections);
+
+setInterval(() => {
+  renderDebugPanel();
+}, 1000);
+
+function getWebSocketEndpoint(apiUrl) {
+  if (process.env.WS_ENDPOINT) return process.env.WS_ENDPOINT;
+
+  return apiUrl !== "https://api.flotiq.com"
+    ? "wss://flotiq-websockets-staging.dev.cdwv.pl"
+    : "wss://sockets.flotiq.com";
+}
+
+function disposeConnection(roomId) {
+  if (!connections.has(roomId)) return;
+
+  const connection = connections.get(roomId);
+  if (connection.isDisposing) return;
+
+  connection.isDisposing = true;
+
+  const { ws, doc } = connection;
+
+  ws.shouldConnect = false;
+  ws.disconnect();
+  ws.destroy();
+
+  if (!doc.isDestroyed) {
+    doc.destroy();
+  }
+
+  connections.delete(roomId);
+  renderDebugPanel();
+}
 
 function getWebSocketConnection(apiKey, roomId, apiUrl) {
   if (!connections.has(roomId)) {
     const ydoc = new Y.Doc();
+    const websocketEnpoint = getWebSocketEndpoint(apiUrl);
 
-    const websocketEnpoint =
-      apiUrl !== "https://api.flotiq.com"
-        ? "wss://flotiq-websockets-staging.dev.cdwv.pl"
-        : "wss://sockets.flotiq.com";
+    const ws = new WebsocketProvider(
+      websocketEnpoint,
+      `ws/editor/${roomId}`, // roomId = "contentType/id"
+      ydoc,
+      {
+        params: { apiKey },
+        connect: true,
+      },
+    );
 
-    const ws = new WebsocketProvider(websocketEnpoint, roomId, ydoc, {
-      params: { apiKey },
-      connect: true,
-    });
-
-    connections.set(roomId, { ws, doc: ydoc });
+    connections.set(roomId, { ws, doc: ydoc, isDisposing: false });
+    renderDebugPanel();
 
     const userData = JSON.parse(window.localStorage["cms.user"]).data;
 
-    ws.on("connection-close", () => {
-      const users = Array.from(ws.awareness.getStates().values()) || [];
-      const flotiqEditors = users.filter(
-        (user) => user?.userId && user.userId !== userData.id,
-      );
-
-      if (!flotiqEditors.length) {
-        ydoc.getMap("vals").clear();
-        ydoc.destroy();
-      }
-
-      ws.awareness.destroy();
-      connections.clear(roomId);
+    ws.on("connection-close", (event) => {
+      console.log(event?.code, event?.reason);
+      if (connections.get(roomId)?.isDisposing) return;
+      renderDebugPanel();
     });
 
-    ws.on("status", (isOpened) => {
-      if (!isOpened) return;
-      const update = Y.encodeStateAsUpdate(ydoc);
-      Y.applyUpdate(ydoc, update);
+    ws.on("status", (event) => {
+      if (event.status === "connected") {
+        const update = Y.encodeStateAsUpdate(ydoc);
+        Y.applyUpdate(ydoc, update);
+      }
+
+      renderDebugPanel();
     });
 
     // Set user information for the connection
@@ -56,14 +89,14 @@ function getWebSocketConnection(apiKey, roomId, apiUrl) {
   return connections.get(roomId);
 }
 
-export function clearConnections() {
-  if (connections.size > 0)
-    connections.forEach((value) => {
-      value.ws.disconnect();
-      value.ws.destroy();
-    });
+export function disconnectFromRoom(roomId) {
+  disposeConnection(roomId);
+}
 
-  connections.clear();
+export function clearConnections() {
+  Array.from(connections.keys()).forEach((roomId) => {
+    disposeConnection(roomId);
+  });
 }
 
 export const getObjectWSConnection = (
@@ -75,14 +108,41 @@ export const getObjectWSConnection = (
 ) => {
   if (!spaceId || !apiUrl || !pluginSettings || !contentType?.name) return;
 
-  const settingsForCtd = getCtdSettings(pluginSettings, contentType.name);
-  if (!settingsForCtd.length) return;
+  const globalSettings = getGlobalSettings(pluginSettings);
+  if (!globalSettings.api_key) return;
 
-  const objectRoomId = `${spaceId}/${contentType.name}/${initialData?.id || "add"}`;
+  const objectRoomId = `${contentType.name}/${initialData?.id || "add"}`;
 
-  return getWebSocketConnection(
-    settingsForCtd[0].api_key,
-    objectRoomId,
-    apiUrl,
-  );
+  return getWebSocketConnection(globalSettings.api_key, objectRoomId, apiUrl);
+};
+
+export const sendRefetchSignal = (
+  pluginSettings,
+  contentType,
+  initialData,
+  spaceId,
+  apiUrl,
+) => {
+  if (!spaceId || !apiUrl || !pluginSettings || !contentType?.name) return;
+
+  const objectRoomId = `${contentType.name}/${initialData?.id || "add"}`;
+  const wsConnection = connections.get(objectRoomId);
+
+  if (!wsConnection?.ws?.ws) return;
+
+  const nativeSocket = wsConnection.ws.ws;
+  if (nativeSocket.readyState !== WebSocket.OPEN) return;
+
+  const docKey =
+    contentType?.name && initialData?.id
+      ? `${contentType.name}/${initialData.id}`
+      : undefined;
+
+  const payload = docKey ? { type: "refetch", docKey } : { type: "refetch" };
+
+  try {
+    nativeSocket.send(JSON.stringify(payload));
+  } catch {
+    // fire-and-forget
+  }
 };

--- a/common/ws-debug-panel.js
+++ b/common/ws-debug-panel.js
@@ -1,0 +1,263 @@
+const openRoomPanels = new Set();
+const DEBUG_STORAGE_KEY = "flotiq-live-preview-debug";
+const DEBUG_STORAGE_POLL_MS = 400;
+const FALSEY_DEBUG_VALUES = new Set([
+  "",
+  "0",
+  "false",
+  "off",
+  "no",
+  "null",
+  "undefined",
+]);
+
+let lastUsedConnections = new Map();
+let isDebugPanelMounted = false;
+let debugPanel;
+let debugSummary;
+let debugSummaryLabel;
+let debugContent;
+
+function getDebugStorageValue() {
+  const browserView = document.defaultView;
+
+  try {
+    return browserView?.sessionStorage?.getItem(DEBUG_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function isDebugPanelEnabled() {
+  const debugValue = getDebugStorageValue();
+  if (debugValue == null) return false;
+
+  const normalizedValue = `${debugValue}`.trim().toLowerCase();
+  return !FALSEY_DEBUG_VALUES.has(normalizedValue);
+}
+
+function clearDebugPanelElements() {
+  if (!debugPanel) return;
+
+  debugPanel.remove();
+  debugPanel = null;
+  debugSummary = null;
+  debugSummaryLabel = null;
+  debugContent = null;
+}
+
+function mountDebugPanel() {
+  if (debugPanel) return;
+
+  debugPanel = document.createElement("details");
+  debugPanel.style.position = "fixed";
+  debugPanel.style.bottom = "0";
+  debugPanel.style.right = "20px";
+  debugPanel.style.width = "360px";
+  debugPanel.style.maxHeight = "60vh";
+  debugPanel.style.overflow = "hidden";
+  debugPanel.style.backgroundColor = "rgba(0,0,0,0.8)";
+  debugPanel.style.color = "white";
+  debugPanel.style.fontSize = "12px";
+  debugPanel.style.zIndex = "9999";
+  debugPanel.style.borderTopLeftRadius = "6px";
+  debugPanel.style.borderTopRightRadius = "6px";
+
+  debugSummary = document.createElement("summary");
+  debugSummary.style.cursor = "pointer";
+  debugSummary.style.padding = "8px";
+  debugSummary.style.userSelect = "none";
+  debugSummary.style.display = "flex";
+  debugSummary.style.alignItems = "center";
+  debugSummary.style.gap = "8px";
+
+  debugSummaryLabel = document.createElement("span");
+  debugSummaryLabel.textContent = "Websocket connections: 0";
+  debugSummary.appendChild(debugSummaryLabel);
+
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.textContent = "✕";
+  closeButton.setAttribute("aria-label", "Hide live preview debug panel");
+  closeButton.style.marginLeft = "auto";
+  closeButton.style.border = "1px solid rgba(255,255,255,0.4)";
+  closeButton.style.background = "transparent";
+  closeButton.style.color = "white";
+  closeButton.style.cursor = "pointer";
+  closeButton.style.lineHeight = "1";
+  closeButton.style.padding = "2px 6px";
+  closeButton.style.borderRadius = "4px";
+  closeButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const browserView = document.defaultView;
+    try {
+      browserView?.sessionStorage?.setItem(DEBUG_STORAGE_KEY, "0");
+    } catch {
+      // Ignore storage write failures and still close the panel in UI.
+    }
+
+    clearDebugPanelElements();
+    isDebugPanelMounted = false;
+  });
+  debugSummary.appendChild(closeButton);
+
+  debugPanel.appendChild(debugSummary);
+
+  debugContent = document.createElement("div");
+  debugContent.style.padding = "8px";
+  debugContent.style.maxHeight = "calc(60vh - 36px)";
+  debugContent.style.overflowY = "auto";
+  debugPanel.appendChild(debugContent);
+
+  document.body.appendChild(debugPanel);
+}
+
+function unmountDebugPanel() {
+  clearDebugPanelElements();
+}
+
+function syncDebugPanelMountState() {
+  const shouldBeMounted = isDebugPanelEnabled();
+  const hasChanged = shouldBeMounted !== isDebugPanelMounted;
+
+  if (hasChanged) {
+    if (shouldBeMounted) mountDebugPanel();
+    else unmountDebugPanel();
+    isDebugPanelMounted = shouldBeMounted;
+  }
+
+  return {
+    isMounted: shouldBeMounted,
+    hasChanged,
+  };
+}
+
+function safeStringify(value) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return "Unable to serialize data";
+  }
+}
+
+function getYjsDocDebugData(doc) {
+  const sharedTypes = {};
+
+  doc.share.forEach((type, key) => {
+    if (typeof type?.toJSON === "function") {
+      sharedTypes[key] = type.toJSON();
+      return;
+    }
+
+    sharedTypes[key] = {
+      type: type?.constructor?.name || "UnknownType",
+    };
+  });
+
+  return {
+    guid: doc.guid,
+    clientId: doc.clientID,
+    collections: sharedTypes,
+  };
+}
+
+function getAwarenessDebugData(ws) {
+  return Array.from(ws.awareness.getStates().entries()).map(
+    ([clientId, state]) => ({ clientId, state }),
+  );
+}
+
+export function renderDebugPanel(connections) {
+  if (connections) lastUsedConnections = connections;
+  else connections = lastUsedConnections;
+
+  const { isMounted } = syncDebugPanelMountState();
+  if (!isMounted || !debugSummaryLabel || !debugContent) return;
+
+  debugSummaryLabel.textContent = `Websocket connections: ${connections.size}`;
+  debugContent.replaceChildren();
+
+  if (!connections.size) {
+    const noConnectionsInfo = document.createElement("div");
+    noConnectionsInfo.textContent = "No active connections";
+    debugContent.appendChild(noConnectionsInfo);
+    return;
+  }
+
+  openRoomPanels.forEach((roomId) => {
+    if (!connections.has(roomId)) {
+      openRoomPanels.delete(roomId);
+    }
+  });
+
+  connections.forEach(({ ws, doc }, roomId) => {
+    const roomPanel = document.createElement("details");
+    roomPanel.style.marginBottom = "6px";
+    roomPanel.style.border = "1px solid rgba(255,255,255,0.2)";
+    roomPanel.style.borderRadius = "4px";
+    roomPanel.style.padding = "4px";
+
+    if (openRoomPanels.has(roomId)) roomPanel.open = true;
+
+    let roomDataPre;
+
+    const updateRoomDataVisibility = () => {
+      if (roomPanel.open) {
+        openRoomPanels.add(roomId);
+
+        if (!roomDataPre) {
+          roomDataPre = document.createElement("pre");
+          roomDataPre.style.margin = "6px 0 0 0";
+          roomDataPre.style.whiteSpace = "pre-wrap";
+          roomDataPre.style.wordBreak = "break-word";
+          roomPanel.appendChild(roomDataPre);
+        }
+
+        const roomData = {
+          yjs: getYjsDocDebugData(doc),
+          awareness: getAwarenessDebugData(ws),
+        };
+
+        roomDataPre.textContent = safeStringify(roomData);
+        return;
+      }
+
+      openRoomPanels.delete(roomId);
+      if (roomDataPre) {
+        roomDataPre.remove();
+        roomDataPre = null;
+      }
+    };
+
+    roomPanel.addEventListener("toggle", updateRoomDataVisibility);
+
+    const roomSummary = document.createElement("summary");
+    roomSummary.style.cursor = "pointer";
+    roomSummary.style.userSelect = "none";
+    roomSummary.textContent = `${roomId} (${ws.wsconnected ? "connected" : "disconnected"})`;
+    roomPanel.appendChild(roomSummary);
+
+    updateRoomDataVisibility();
+
+    debugContent.appendChild(roomPanel);
+  });
+}
+
+function onDebugStorageUpdate() {
+  const { isMounted, hasChanged } = syncDebugPanelMountState();
+  if (isMounted && hasChanged) {
+    renderDebugPanel();
+  }
+}
+
+const browserView = document.defaultView;
+
+browserView?.addEventListener("storage", (event) => {
+  if (event.storageArea !== browserView.sessionStorage) return;
+  if (event.key !== DEBUG_STORAGE_KEY) return;
+  onDebugStorageUpdate();
+});
+
+setInterval(onDebugStorageUpdate, DEBUG_STORAGE_POLL_MS);

--- a/common/yjs.js
+++ b/common/yjs.js
@@ -2,6 +2,18 @@ import * as Y from "yjs";
 import diff from "fast-diff";
 import { deepAssignKeyValue } from "./lib";
 
+const parseFieldPath = (fieldName) => {
+  return fieldName.split(/[[.\]]/).filter((keyPart) => !!keyPart);
+};
+
+const isSameFieldPath = (currentPath, targetPath) => {
+  if (!targetPath || currentPath.length !== targetPath.length) return false;
+
+  return currentPath.every(
+    (pathSegment, index) => pathSegment === targetPath[index],
+  );
+};
+
 /** Convert a fast-diff result to a YJS delta. */
 const diffToDelta = (diffResult) => {
   return diffResult
@@ -24,9 +36,11 @@ export const updateObjectDoc = (
   isArrayChanged,
 ) => {
   const parsedObject = {};
+  const arrayChangePath = isArrayChanged ? parseFieldPath(fieldName) : null;
+
   deepAssignKeyValue(fieldName, fieldValue, parsedObject);
   valsMap.doc.transact(() => {
-    deepAssignToDoc(parsedObject, valsMap, schema, isArrayChanged);
+    deepAssignToDoc(parsedObject, valsMap, schema, arrayChangePath);
   });
 };
 
@@ -69,13 +83,15 @@ export const deepAssignToDoc = (
   parsedObject,
   parentType,
   schema,
-  shouldCheckArrayItems = false,
+  arrayChangePath = null,
   isArray = false,
+  currentPath = [],
 ) => {
   Object.entries(parsedObject)
     .filter(([fieldName]) => (isArray && schema) || !!schema[fieldName])
     .forEach(([fieldName, value]) => {
       const fieldSchema = !isArray ? schema[fieldName] : schema;
+      const nextPath = currentPath.concat(fieldName);
 
       const yType = updateParent(
         parentType,
@@ -88,14 +104,30 @@ export const deepAssignToDoc = (
       if (yType) {
         if (fieldSchema.type === "array") {
           yType.doc.transact(() => {
-            if (shouldCheckArrayItems && value.length !== yType.length) {
-              const lengthDiff = yType.length - value.length;
-              yType.delete(yType.length - lengthDiff, lengthDiff);
+            if (
+              isSameFieldPath(nextPath, arrayChangePath) &&
+              yType.length > value.length
+            ) {
+              yType.delete(value.length, yType.length - value.length);
             }
-            deepAssignToDoc(value, yType, fieldSchema.items, true, true);
+            deepAssignToDoc(
+              value,
+              yType,
+              fieldSchema.items,
+              arrayChangePath,
+              true,
+              nextPath,
+            );
           });
         } else if (fieldSchema.type === "object") {
-          deepAssignToDoc(value, yType, fieldSchema.properties, true);
+          deepAssignToDoc(
+            value,
+            yType,
+            fieldSchema.properties,
+            arrayChangePath,
+            false,
+            nextPath,
+          );
         } else {
           const delta = diffToDelta(diff(yType.toString(), value));
           yType.applyDelta(delta);

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -5,12 +5,14 @@ import inlineImportPlugin from "esbuild-plugin-inline-import";
 import url from "postcss-url";
 import postcss from "postcss";
 import { copy } from "esbuild-plugin-copy";
+import dotenvFlow from "dotenv-flow";
 
 import http from "node:http";
 import https from "node:https";
 import fs from "fs";
 
 const watch = process.argv.includes("--watch");
+dotenvFlow.config({ silent: true });
 
 function formatDuration(seconds) {
   const time = {
@@ -59,6 +61,9 @@ const context = await esbuild.context({
   minify: true,
   sourcemap: true,
   outfile: "dist/index.js",
+  define: {
+    "process.env.WS_ENDPOINT": JSON.stringify(process.env.WS_ENDPOINT ?? ""),
+  },
 
   plugins: [
     copy({

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "chalk": "^5.3.0",
+    "dotenv-flow": "^4.1.0",
     "esbuild-plugin-copy": "^2.1.1",
     "fast-diff": "^1.3.0",
     "i18next": "^24.2.2",

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -1,6 +1,6 @@
 {
-  "id": "dev-flotiq.live-preview",
-  "name": "[DEV] Live Preview",
+  "id": "flotiq.live-preview",
+  "name": "Live Preview",
   "description": "The Live Preview Plugin is used for real-time transmission of data from content object forms, allowing the end application to display content changes live.",
   "version": "0.8.0",
   "repository": "https://github.com/flotiq/flotiq-ui-plugin-live-preview",

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -1,8 +1,8 @@
 {
-  "id": "flotiq.live-preview",
-  "name": "Live Preview",
+  "id": "dev-flotiq.live-preview",
+  "name": "[DEV] Live Preview",
   "description": "The Live Preview Plugin is used for real-time transmission of data from content object forms, allowing the end application to display content changes live.",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "repository": "https://github.com/flotiq/flotiq-ui-plugin-live-preview",
   "url": "https://localhost:3053/index.js",
   "permissions": []

--- a/plugins/field-config/user-colors.js
+++ b/plugins/field-config/user-colors.js
@@ -21,5 +21,5 @@ export const strToChecksum = (...args) => {
 export const getUserColor = (userId, light = false) => {
   const randomHue = strToChecksum(userId, "hue") % 360;
   const randomSaturation = strToChecksum(userId, "saturation") % 100;
-  return `hsl(${randomHue} ${randomSaturation}% ${light ? "80%" : "30%"}`;
+  return `hsl(${randomHue} ${Math.abs(randomSaturation)}% ${light ? "80%" : "30%"})`;
 };

--- a/plugins/form-after-submit/index.js
+++ b/plugins/form-after-submit/index.js
@@ -1,0 +1,29 @@
+import { sendRefetchSignal } from "../../common/websockets";
+
+export const handleFormAfterSubmit = (
+  data,
+  getPluginSettings,
+  getSpaceId,
+  getApiUrl,
+) => {
+  if (!data || typeof data !== "object") return;
+
+  if (!data.success) return;
+
+  const contentObject = data.contentObject;
+  const contentTypeName =
+    data.contentType?.name ||
+    data.contentTypeDefinition?.name ||
+    contentObject?.internal?.contentType;
+  const contentType = contentTypeName ? { name: contentTypeName } : null;
+
+  if (!contentType?.name || !contentObject?.id) return;
+
+  sendRefetchSignal(
+    getPluginSettings(),
+    contentType,
+    contentObject,
+    getSpaceId(),
+    getApiUrl(),
+  );
+};

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -10,6 +10,7 @@ import { handleChangeTranslation } from "./mulitlingual-translations";
 import { handleFormFieldListenrsAdd } from "./field-listeners";
 import { handleSecondaryColumnAdd } from "./form-secondary-column";
 import { handleFormRelationChanged } from "./form-relation-changed";
+import { handleFormAfterSubmit } from "./form-after-submit";
 
 const rerenderFn = {};
 
@@ -68,6 +69,10 @@ registerFn(
     handler.on("flotiq.form.relation::after-submit", (data) => {
       handleFormRelationChanged(data, getPluginSettings, getSpaceId, getApiUrl);
     });
+
+    handler.on("flotiq.form::after-submit", (data) =>
+      handleFormAfterSubmit(data, getPluginSettings, getSpaceId, getApiUrl),
+    );
 
     handler.on("flotiq-multilingual.translation::changed", (data) => {
       handleChangeTranslation(data, getPluginSettings, getSpaceId, getApiUrl);

--- a/plugins/sidebar-panel/URLGenerator.js
+++ b/plugins/sidebar-panel/URLGenerator.js
@@ -25,12 +25,20 @@ export class URLGenerator {
       object.internal?.contentType,
     );
 
+    const identifyingFields = {};
     const path = this.config.route_template.replace(
       /{(?<key>[^{}]+)}/g,
       (...params) => {
         const { key } = params[4];
-        return deepReadKeyValue(key, object);
+        const value = deepReadKeyValue(key, object);
+        identifyingFields[key] = `${value ?? ""}`;
+        return value;
       },
+    );
+
+    baseURLInstance.searchParams.set(
+      "identifyingFields",
+      JSON.stringify(identifyingFields),
     );
 
     baseURLInstance.searchParams.set("live-preview", "true");

--- a/plugins/sidebar-panel/index.js
+++ b/plugins/sidebar-panel/index.js
@@ -4,8 +4,12 @@ import {
 } from "../../common/plugin-element-cache";
 import { getCtdSettings } from "../../common/settings-parser";
 import pluginInfo from "../../plugin-manifest.json";
-import { clearConnections } from "../../common/websockets";
-import { createPanelElement, updatePanelElement } from "./panel-elements";
+import { disconnectFromRoom } from "../../common/websockets";
+import {
+  createMockElement,
+  createPanelElement,
+  updatePanelElement,
+} from "./panel-elements";
 
 export const handlePanelPlugin = (
   { contentType, contentObject, form, create },
@@ -15,29 +19,33 @@ export const handlePanelPlugin = (
 ) => {
   if (!contentType?.name || !form) return null;
   const settingsForCtd = getCtdSettings(getPluginSettings(), contentType.name);
-  if (!settingsForCtd?.length) return null;
-
+  const ctdHaspreview = !!settingsForCtd?.length;
   const cacheKey = `${pluginInfo.id}-${contentType.name}-${contentObject?.id || "new"}`;
   let pluginContainer = getCachedElement(cacheKey)?.element;
   if (!pluginContainer) {
-    pluginContainer = createPanelElement(create);
+    pluginContainer = ctdHaspreview
+      ? createPanelElement(create)
+      : createMockElement();
 
     addElementToCache(pluginContainer, cacheKey, null, () => {
-      clearConnections();
+      const roomId = `${contentType.name}/${contentObject?.id || "add"}`;
+      disconnectFromRoom(roomId);
     });
   }
 
-  const spaceId = getSpaceId();
+  if (ctdHaspreview) {
+    const spaceId = getSpaceId();
 
-  const objectData = { ...contentObject, ...form.getValues() };
-  updatePanelElement(
-    pluginContainer,
-    settingsForCtd,
-    objectData,
-    spaceId,
-    create,
-    rerenderColumn,
-  );
+    const objectData = { ...contentObject, ...form.getValues() };
+    updatePanelElement(
+      pluginContainer,
+      settingsForCtd,
+      objectData,
+      spaceId,
+      create,
+      rerenderColumn,
+    );
+  }
 
   return pluginContainer;
 };

--- a/plugins/sidebar-panel/panel-elements.js
+++ b/plugins/sidebar-panel/panel-elements.js
@@ -15,6 +15,22 @@ export const openInNewTab = (link) => {
   }
 };
 
+/**
+ * Create simple element that will help us receive detach signal later, but is not visible in the UI.
+ */
+export const createMockElement = () => {
+  const element = document.createElement("div");
+  element.addEventListener(
+    "flotiq.attached",
+    () => {
+      if (!element.parentElement) return;
+      element.parentElement.style.display = "none";
+    },
+    true,
+  );
+  return element;
+};
+
 export const createPanelElement = (disabled) => {
   const panelElement = document.createElement("div");
   panelElement.classList.add("plugin-live-preview");

--- a/yarn.lock
+++ b/yarn.lock
@@ -435,6 +435,18 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv-flow@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-flow/-/dotenv-flow-4.1.0.tgz#a78e79dcaf08a48200192eb5ed1e5af11062b861"
+  integrity sha512-0cwP9jpQBQfyHwvE0cRhraZMkdV45TQedA8AAUZMsFzvmLcQyc1HPv+oX0OOYwLFjIlvgVepQ+WuQHbqDaHJZg==
+  dependencies:
+    dotenv "^16.0.0"
+
+dotenv@^16.0.0:
+  version "16.6.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
+  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
+
 encoding-down@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/encoding-down/-/encoding-down-6.3.0.tgz#b1c4eb0e1728c146ecaef8e32963c549e76d082b"


### PR DESCRIPTION
This plugin implements new protocol changes for collab gateway, allowing users to modify any document and see its changes in the parent docs that are related to current doc.

To test this as local plugin, make sure to create `.env.local` file that includes the following entry:

```
WS_ENDPOINT=ws://localhost:1234
```

## Changelog: minor
### Added
* websocket debug panel for inspecting active rooms, Yjs documents and awareness state #27596
* send refetch signal after successful form submit so live preview can reload saved content #27596

### Changed
* redesigned websocket integration to work with the new collaboration gateway #27596
* generated live preview URLs now include `identifyingFields` resolved from the route template #27596

### Fixed
* array editing no longer removes objects from the Yjs document unexpectedly
* colors assigned to editor no longer produce incorrect lightness value
* changes made in list object will no longer remove the remaining list items
* connection is now correctly closed only for the edited document
* connection is now correctly reestablished when any network failures happen while working on the document
